### PR TITLE
Add simple sourcemap support for modified files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,22 @@
-> Gulp plugin allow modify file in .pipe
+# gulp-modify-file
+
+A gulp plugin for modifying files in your gulp `.pipe`.
+
+## Install
+```shell
+$ npm install gulp-modify-file --save-dev
+```
+
+## How to use
+Your callback function will receive three arguments: the contents of the file, the path to the file,
+and gulp's internal `file` object, for context. Return a string or buffer containing the new desired
+contents of the file.
 
 ```javascript
 const gulp = require('gulp')
+const modifyFile = require('gulp-modify-file')
 
 gulp.task('js', () => {
-    const modifyFile = require('gulp-modify-file')
-
     return gulp
     .src('app/**/*.js')
     .pipe(modifyFile((content, path, file) => {
@@ -17,3 +28,41 @@ gulp.task('js', () => {
     .pipe(gulp.dest('build'))
 })
 ```
+
+## Specifying source mappings
+If you're using `gulp-sourcemaps` for your pipeline, modifying file contents (especially when
+adding and removing lines) will cause your source maps to become inaccurate. You can fix this
+by providing source mappings using the optional _fourth parameter_.
+
+Note that if you make use of this feature, you should provide at least one mapping for every
+line in the output content. Any line without a mapping will not resolve to a source line
+(which may be exactly what you want, in the case of shims or inserted code).
+
+```javascript
+const gulp = require('gulp')
+const modifyFile = require('gulp-modify-file')
+
+gulp.task('js', () => {
+    return gulp
+    .src('app/**/*.js')
+    .pipe(modifyFile((content, path, file, sourcemap) => {
+        const lines = content.split('\n')
+
+        // In the generated (aka output) file, line 2 maps to line 1 of the original,
+        // line 3 maps to line 2, etc. The first and last lines will have no mapping,
+        // which makes sense.
+        for (let i = 0; i < lines.length; i++) {
+            sourcemap.map({ generated: { line: i + 1, column: 0 }, original: { line: i, column: 0 } })
+        }
+
+        lines.unshift('(function (){\n')
+        lines.push('\n})()')
+
+        // The mappings provided above will automatically be applied to the current source map
+        // being maintained by gulp-sourcemaps.
+        return lines.join('\n')
+    }))
+    .pipe(gulp.dest('build'))
+})
+```
+

--- a/index.js
+++ b/index.js
@@ -1,15 +1,42 @@
 'use strict'
 
 const through = require('through2')
+const sourceMap = require('source-map');
+const applySourceMap = require('vinyl-sourcemaps-apply');
 
 module.exports = function (fn) {
     return through.obj(function (file, enc, cb) {
-        const contents = fn(String(file.contents), file.path, file) || file.contents
+        const sourceMappings = [];
+        const sourceMapInterface = {
+            map: function (entry) {
+                sourceMappings.push(entry);
+            }
+        };
+
+        const contents = fn(String(file.contents), file.path, file, sourceMapInterface) || file.contents;
 
         if (file.isBuffer() === true) {
-            file.contents = new Buffer(contents)
+            file.contents = new Buffer(contents);
         }
 
-        cb(null, file)
-    })
+        // If the user doesn't make use of the source mapping interface, we won't bother
+        // examining or appending to the existing source map(s).
+        if (sourceMappings.length > 0) {
+            if (!file.sourceMap) {
+                throw new Error('Add gulp-sourcemaps to your pipeline before specifying source mappings');
+            }
+
+            let generator = new sourceMap.SourceMapGenerator({
+                file: file.sourceMap.file
+            });
+
+            sourceMappings.forEach(function (mapping) {
+                generator.addMapping(Object.assign({ source: file.sourceMap.file }, mapping));
+            });
+
+            applySourceMap(file, generator.toString()); 
+        }
+
+        cb(null, file);
+    });
 }

--- a/package.json
+++ b/package.json
@@ -3,31 +3,27 @@
     "name": "gulp-modify-file",
     "license": "MIT",
     "version": "1.0.1",
-
     "author": {
         "name": "Eduardo Pérez-Bermejo",
         "email": "ifedu@outlook.com",
         "url": "http://www.github.com/ifedu/gulp-modify-file"
     },
-
     "dependencies": {
         "gulp": "3.9.1",
-        "through2": "2.0.3"
+        "source-map": "^0.7.3",
+        "through2": "2.0.3",
+        "vinyl-sourcemaps-apply": "^0.2.1"
     },
-
     "engines": {
         "node": ">= 4.0"
     },
-
     "repository": {
         "type": "git",
         "url": "https://github.com/ifedu/gulp-modify-file"
     },
-
     "files": [
         "index.js"
     ],
-
     "keywords": [
         "gulp",
         "modify",


### PR DESCRIPTION
### GOAL

Make it easier for people that are modifying file content to keep source mappings correct.

### CHANGES

- Add an optional fourth parameter to the callback function, which provides a single function (`.map`), allowing the user to specify source mapping entries.
- If the user makes use of the mapping function, the plugin will automatically create and apply a source map for them on top of the current `gulp-sourcemaps` map for that file.
- Updated README to include an example of the syntax.

This PR is up for feedback; I think this is relatively safe and does not affect current users of the plugin, but is at least a minor version bump.  Might also benefit from some unit tests, which I haven't added yet but might be able to whip up if interested.

