### PR TITLE
Ensure original file content is not replaced

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,11 +5,12 @@ const through = require('through2')
 module.exports = function (fn) {
     return through.obj(function (file, enc, cb) {
         const contents = fn(String(file.contents), file.path, file) || file.contents
+        const modifiedFile = file.clone()
 
         if (file.isBuffer() === true) {
-            file.contents = new Buffer(contents)
+            modifiedFile.contents = new Buffer(contents)
         }
 
-        cb(null, file)
+        cb(null, modifiedFile)
     })
 }


### PR DESCRIPTION
### CHANGE

Ensure that the plugin returns a modified clone of the original file, rather than modifying the file in-place.  This change should be a no-op for most uses, but allows the plugin to play nicely with plugins like `vinyl-fork`.