### PR TITLE
Updated dependencies and uses Buffer function

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function (fn) {
         const contents = fn(String(file.contents), file.path, file) || file.contents
 
         if (file.isBuffer() === true) {
-            file.contents = new Buffer(contents)
+            file.contents = new Buffer.from(contents)
         }
 
         cb(null, file)

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     },
 
     "dependencies": {
-        "gulp": "3.9.1",
-        "through2": "2.0.3"
+        "gulp": "4.0.2",
+        "through2": "3.0.1"
     },
 
     "engines": {


### PR DESCRIPTION
NPM gives a high vulnerability warning on gulp version < 4.0.0, because of its dependencies. This updated the version of gulp and through2.
JS gives a deprecation warning on `Buffer()`, suggestion to use `Buffer.from()` instead.